### PR TITLE
Set up the checkout file, build, and register script

### DIFF
--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/editor';
+
+registerBlockType( 'woocommerce/checkout', {
+	title: __( 'Checkout', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<InnerBlocks
+				template={ [
+					[
+						'core/heading',
+						{
+							content: __( 'Billing', 'woo-gutenberg-products-block' ),
+							level: 3,
+						},
+					],
+				] }
+				templateLock="all"
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -17,4 +17,8 @@ setCategories( [
 		title: __( 'WooCommerce', 'woo-gutenberg-products-block' ),
 		icon: <IconWoo />,
 	},
+	{
+		slug: 'woocommerce-checkout',
+		title: __( 'WooCommerce Checkout', 'woo-gutenberg-products-block' ),
+	},
 ] );

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -146,6 +146,7 @@ class WGPB_Block_Library {
 		self::register_script( 'wc-product-top-rated', plugins_url( 'build/product-top-rated.js', WGPB_PLUGIN_FILE ), $block_dependencies );
 		self::register_script( 'wc-products-attribute', plugins_url( 'build/products-attribute.js', WGPB_PLUGIN_FILE ), $block_dependencies );
 		self::register_script( 'wc-featured-product', plugins_url( 'build/featured-product.js', WGPB_PLUGIN_FILE ), $block_dependencies );
+		self::register_script( 'wc-checkout', plugins_url( 'build/checkout.js', WGPB_PLUGIN_FILE ), $block_dependencies );
 	}
 
 	/**
@@ -335,6 +336,14 @@ class WGPB_Block_Library {
 			array(
 				'render_callback' => array( 'WGPB_Block_Featured_Product', 'render' ),
 				'editor_script'   => 'wc-featured-product',
+				'editor_style'    => 'wc-block-editor',
+				'style'           => 'wc-block-style',
+			)
+		);
+		register_block_type(
+			'woocommerce/checkout',
+			array(
+				'editor_script'   => 'wc-checkout',
 				'editor_style'    => 'wc-block-editor',
 				'style'           => 'wc-block-style',
 			)

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -55,6 +55,8 @@ const GutenbergBlocksConfig = {
 		'featured-product': './assets/js/blocks/featured-product/index.js',
 		// Global styles
 		styles: [ './assets/css/style.scss', './assets/css/editor.scss' ],
+		// Checkout blocks
+		checkout: './assets/js/blocks/checkout/index.js',
 	},
 	output: {
 		path: path.resolve( __dirname, './build/' ),


### PR DESCRIPTION
This adds a new folder `blocks/checkout` for all the checkout-related blocks, we can then put all the child-blocks in subfolders and import into the `checkout/index.js` file– this way we don't need to register each in PHP as well as in JS.

I've also added a `woocommerce-checkout` category to collect all our blocks in one place in the inserter, but we'll remove that once we're done.

To test

- Build this branch
- Go to insert a block, you should see WooCommerce Checkout category
- Inside, there's a Checkout block
- It inserts a group with just the Header block