### PR TITLE
Add checkout block inline script settings

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -398,12 +398,10 @@ class WGPB_Block_Library {
 		);
 
 		// Checkout settings.
-		$packages = WC()->shipping->get_packages();
-
 		$checkout_settings = array(
 			'isUserShopManager'  => current_user_can( 'manage_woocommerce' ),
 			'hasCouponsEnabled'  => wc_coupons_enabled(),
-			'hasShippingEnabled' => ! empty( $packages ),
+			'hasShippingEnabled' => wc_get_shipping_method_count() > 0,
 		);
 		?>
 		<script type="text/javascript">

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -402,7 +402,7 @@ class WGPB_Block_Library {
 
 		$checkout_settings = array(
 			'isUserShopManager' => current_user_can( 'manage_woocommerce' ),
-			'isCouponsEnabled'  => wc_coupons_enabled(),
+			'hasCouponsEnabled' => wc_coupons_enabled(),
 			'isShippingEnabled' => ! empty( $packages ),
 		);
 		?>

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -396,10 +396,20 @@ class WGPB_Block_Library {
 			'default_height'    => wc_get_theme_support( 'featured_block::default_height', 500 ),
 			'isLargeCatalog'    => $product_counts->publish > 200,
 		);
+
+		// Checkout settings.
+		$packages = WC()->shipping->get_packages();
+
+		$checkout_settings = array(
+			'isUserShopManager' => current_user_can( 'manage_woocommerce' ),
+			'isCouponsEnabled'  => wc_coupons_enabled(),
+			'isShippingEnabled' => ! empty( $packages ),
+		);
 		?>
 		<script type="text/javascript">
 			var wcSettings = wcSettings || JSON.parse( decodeURIComponent( '<?php echo rawurlencode( wp_json_encode( $settings ) ); ?>' ) );
 			var wc_product_block_data = JSON.parse( decodeURIComponent( '<?php echo rawurlencode( wp_json_encode( $block_settings ) ); ?>' ) );
+			var wc_checkout_block_data = JSON.parse( decodeURIComponent( '<?php echo rawurlencode( wp_json_encode( $checkout_settings ) ); ?>' ) );
 		</script>
 		<?php
 	}

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -401,9 +401,9 @@ class WGPB_Block_Library {
 		$packages = WC()->shipping->get_packages();
 
 		$checkout_settings = array(
-			'isUserShopManager' => current_user_can( 'manage_woocommerce' ),
-			'hasCouponsEnabled' => wc_coupons_enabled(),
-			'isShippingEnabled' => ! empty( $packages ),
+			'isUserShopManager'  => current_user_can( 'manage_woocommerce' ),
+			'hasCouponsEnabled'  => wc_coupons_enabled(),
+			'hasShippingEnabled' => ! empty( $packages ),
 		);
 		?>
 		<script type="text/javascript">

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -398,10 +398,22 @@ class WGPB_Block_Library {
 		);
 
 		// Checkout settings.
+		$active_methods   = array();
+		$shipping_methods = WC()->shipping()->get_shipping_methods();
+		foreach ( $shipping_methods as $id => $shipping_method ) {
+			if ( isset( $shipping_method->enabled ) && 'yes' === $shipping_method->enabled ) {
+				$active_methods[ $id ] = array(
+					'title'       => $shipping_method->method_title,
+					'description' => $shipping_method->method_description,
+				);
+			}
+		}
+
 		$checkout_settings = array(
-			'isUserShopManager'  => current_user_can( 'manage_woocommerce' ),
-			'hasCouponsEnabled'  => wc_coupons_enabled(),
-			'hasShippingEnabled' => wc_get_shipping_method_count() > 0,
+			'isUserShopManager'     => current_user_can( 'manage_woocommerce' ),
+			'hasCouponsEnabled'     => wc_coupons_enabled(),
+			'hasShippingEnabled'    => wc_get_shipping_method_count() > 0,
+			'activeShippingMethods' => $active_methods,
 		);
 		?>
 		<script type="text/javascript">


### PR DESCRIPTION
Outputs checkout block settings via `admin_print_footer_scripts()`:

- Is current user a shop manager?
- Coupons enabled?
- Shipping enabled?

To test, check if `wc_checkout_block_data` global object exists when creating a new post/page in the new editor.