### PR TITLE
Add checkout select block

### DIFF
--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -4,6 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
+export { default as CheckoutSelect } from './select';
 
 registerBlockType( 'woocommerce/checkout', {
 	title: __( 'Checkout', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -4,7 +4,8 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
-export { default as CheckoutSelect } from './select';
+
+import './select';
 
 registerBlockType( 'woocommerce/checkout', {
 	title: __( 'Checkout', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/checkout/select/index.js
+++ b/assets/js/blocks/checkout/select/index.js
@@ -20,6 +20,7 @@ registerBlockType( 'woocommerce/checkout-select', {
 
 		return (
 			<SelectControl
+				disabled
 				label={ label }
 				value={ null }
 				options={ [

--- a/assets/js/blocks/checkout/select/index.js
+++ b/assets/js/blocks/checkout/select/index.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { SelectControl } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/checkout-select', {
+	title: __( 'Checkout select', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	attributes: {
+		label: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit( { attributes } ) {
+		const { label } = attributes;
+
+		return (
+			<SelectControl
+				label={ label }
+				value={ null }
+				options={ [
+					{ label: '', value: '' },
+				] }
+				onChange={ () => {} }
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/select/index.js
+++ b/assets/js/blocks/checkout/select/index.js
@@ -9,6 +9,9 @@ registerBlockType( 'woocommerce/checkout-select', {
 	title: __( 'Checkout select', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
 	attributes: {
 		label: {
 			type: 'string',


### PR DESCRIPTION
This PR creates the checkout select block. When added to a page, it currently only shows an empty select box, but if a label was set, it would be displayed on top of it.

### Questions
* Would it be better to use a regular `<select>` element instead of the `<SelectControl>` Gutenberg component?
* Is there a better way to avoid it being interactive than using `disabled`?

### How to test the changes in this Pull Request:

1. Edit any page or post and add a _Checkout select_ block.
2. Verify the block exists and it can be added without errors.