### PR TITLE
Create the "Checkout Cart" block

### DIFF
--- a/assets/js/blocks/checkout/cart/editor.scss
+++ b/assets/js/blocks/checkout/cart/editor.scss
@@ -1,0 +1,18 @@
+.wc-checkout__cart {}
+
+.wc-checkout__cart-table {
+	border-collapse: collapse;
+	width: 100%;
+	// twentynineteen compat?
+	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
+
+	td,
+	th {
+		padding: 0.5em 0.3em;
+		border: 1px solid currentColor;
+	}
+
+	.wc-checkout__cart-shipping-list {
+		padding-left: 1em;
+	}
+}

--- a/assets/js/blocks/checkout/cart/index.js
+++ b/assets/js/blocks/checkout/cart/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
+registerBlockType( 'woocommerce/checkout-cart', {
+	title: __( 'Cart', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<div className="wc-checkout__cart">
+				<h3>{ __( 'Your Order', 'woo-gutenberg-products-block' ) }</h3>
+				<table className="wc-checkout__cart-table">
+					<thead>
+						<tr>
+							<th>{ __( 'Product', 'woo-gutenberg-products-block' ) }</th>
+							<th>{ __( 'Total', 'woo-gutenberg-products-block' ) }</th>
+						</tr>
+					</thead>
+					<tbody>
+						<tr>
+							<td>{ __( 'T-Shirt with Logo × 1', 'woo-gutenberg-products-block' ) }</td>
+							<td>$4.00</td>
+						</tr>
+					</tbody>
+					<tfoot>
+						<tr>
+							<th>{ __( 'Subtotal', 'woo-gutenberg-products-block' ) }</th>
+							<td>$4.00</td>
+						</tr>
+
+						<tr>
+							<th>{ __( 'Shipping', 'woo-gutenberg-products-block' ) }</th>
+							<td>
+								<ul className="wc-checkout__cart-shipping-list">
+									<li>Shipping method: $1</li>
+								</ul>
+							</td>
+						</tr>
+
+						<tr>
+							<th>{ __( 'Total', 'woo-gutenberg-products-block' ) }</th>
+							<td>$5.00</td>
+						</tr>
+					</tfoot>
+				</table>
+			</div>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -5,6 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import './cart';
 import './select';
 
 registerBlockType( 'woocommerce/checkout', {
@@ -25,6 +29,7 @@ registerBlockType( 'woocommerce/checkout', {
 							level: 3,
 						},
 					],
+					[ 'woocommerce/checkout-cart' ],
 				] }
 				templateLock="all"
 			/>


### PR DESCRIPTION
This just adds a read-only "Cart" preview block:

<img width="569" alt="checkout-cart" src="https://user-images.githubusercontent.com/541093/59025050-9087e900-8853-11e9-8d9a-52fc71fbbc98.png">

You can add this alone ("Cart" block), or add the "Checkout" block which includes this.

There's some "real data" we'll need to show the shipping methods & localize the currency in totals (maybe importing in `@woocommerce/currency`?)
