### PR TITLE
Create checkbox, input, radio and textarea form fields

### DIFF
--- a/assets/js/blocks/checkout/checkbox/index.js
+++ b/assets/js/blocks/checkout/checkbox/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { CheckboxControl } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/checkout-checkbox', {
+	title: __( 'Checkout checkbox', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	attributes: {
+		heading: {
+			type: 'string',
+			default: '',
+		},
+		label: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit( { attributes } ) {
+		const { heading, label } = attributes;
+
+		return (
+			<CheckboxControl
+				disabled
+				heading={ heading }
+				label={ label }
+				checked={ false }
+				onChange={ () => {} }
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -9,7 +9,11 @@ import { InnerBlocks } from '@wordpress/editor';
  * Internal dependencies
  */
 import './cart';
+import './checkbox';
+import './input';
+import './radio';
 import './select';
+import './textarea';
 
 registerBlockType( 'woocommerce/checkout', {
 	title: __( 'Checkout', 'woo-gutenberg-products-block' ),

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -6,7 +6,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { TextControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-input', {
-	title: __( 'Checkout input', 'woo-gutenberg-products-block' ),
+	title: __( 'Checkout Input', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -1,0 +1,41 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { TextControl } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/checkout-input', {
+	title: __( 'Checkout input', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	attributes: {
+		label: {
+			type: 'string',
+			default: '',
+		},
+		type: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit( { attributes } ) {
+		const { label, type } = attributes;
+
+		return (
+			<TextControl
+				disabled
+				label={ label }
+				type={ type }
+				value=""
+				onChange={ () => {} }
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/radio/index.js
+++ b/assets/js/blocks/checkout/radio/index.js
@@ -6,7 +6,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { RadioControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-radio', {
-	title: __( 'Checkout radio', 'woo-gutenberg-products-block' ),
+	title: __( 'Checkout Radio', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {

--- a/assets/js/blocks/checkout/radio/index.js
+++ b/assets/js/blocks/checkout/radio/index.js
@@ -1,0 +1,43 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { RadioControl } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/checkout-radio', {
+	title: __( 'Checkout radio', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	attributes: {
+		label: {
+			type: 'string',
+			default: '',
+		},
+		options: {
+			type: 'array',
+			default: [
+				{ label: '', value: '' },
+			],
+		},
+	},
+	edit( { attributes } ) {
+		const { label, options } = attributes;
+
+		return (
+			<RadioControl
+				disabled
+				label={ label }
+				selected={ null }
+				options={ options }
+				onChange={ () => {} }
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/textarea/index.js
+++ b/assets/js/blocks/checkout/textarea/index.js
@@ -6,7 +6,7 @@ import { registerBlockType } from '@wordpress/blocks';
 import { TextareaControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-textarea', {
-	title: __( 'Checkout textarea', 'woo-gutenberg-products-block' ),
+	title: __( 'Checkout Textarea', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {

--- a/assets/js/blocks/checkout/textarea/index.js
+++ b/assets/js/blocks/checkout/textarea/index.js
@@ -1,0 +1,36 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { TextareaControl } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/checkout-textarea', {
+	title: __( 'Checkout textarea', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	attributes: {
+		label: {
+			type: 'string',
+			default: '',
+		},
+	},
+	edit( { attributes } ) {
+		const { label } = attributes;
+
+		return (
+			<TextareaControl
+				disabled
+				label={ label }
+				value=""
+				onChange={ () => {} }
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );


### PR DESCRIPTION
Same as #3 with checkbox, input, radio and textarea form fields.

### How to test the changes in this Pull Request:

1. Edit any page or post and add a _Checkout checkbox_, _Checkout input_, _Checkout radio_ and _Checkout textarea_ blocks.
2. Verify the blocks exist, and they can be added without errors.

Or... add them as children of the `woocommerce/checkout` block so you can set their `label`, `options` and other attributes.
