### PR TITLE
Add enabled payment gateways to wc_checkout_block_data

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -410,7 +410,7 @@ class WGPB_Block_Library {
 			'isLargeCatalog'    => $product_counts->publish > 200,
 		);
 
-		// Checkout settings.
+		// Shipping methods.
 		$active_methods   = array();
 		$shipping_methods = WC()->shipping()->get_shipping_methods();
 		foreach ( $shipping_methods as $id => $shipping_method ) {
@@ -422,7 +422,33 @@ class WGPB_Block_Library {
 			}
 		}
 
-		// Set up session and cart to grab checkout fields.
+		// Payment gateways.
+		$payment_gateways         = WC()->payment_gateways->get_available_payment_gateways();
+		$enabled_payment_gateways = array();
+		foreach ( $payment_gateways as $id => $payment_gateway ) {
+			if ( 'yes' === $payment_gateway->enabled ) {
+				$enabled_payment_gateways[ $id ] = array(
+					'id'                => $id,
+					'title'             => $payment_gateway->method_title,
+					'description'       => $payment_gateway->method_description,
+					'order_button_text' => $payment_gateway->order_button_text,
+					'icon'              => wp_kses(
+						$payment_gateway->get_icon(),
+						array(
+							'img' => array(
+								'alt'    => array(),
+								'class'  => array(),
+								'height' => array(),
+								'src'    => array(),
+								'width'  => array(),
+							),
+						)
+					),
+				);
+			}
+		}
+
+		// Billing fields.
 		$session_class = apply_filters( 'woocommerce_session_handler', 'WC_Session_Handler' );
 		WC()->session  = new $session_class();
 		WC()->session->init();
@@ -430,11 +456,12 @@ class WGPB_Block_Library {
 		$billing_fields = WC()->checkout->get_checkout_fields( 'billing' );
 
 		$checkout_settings = array(
-			'isUserShopManager'     => current_user_can( 'manage_woocommerce' ),
-			'hasCouponsEnabled'     => wc_coupons_enabled(),
-			'hasShippingEnabled'    => wc_get_shipping_method_count() > 0,
-			'activeShippingMethods' => $active_methods,
-			'billingFields'         => $billing_fields,
+			'isUserShopManager'      => current_user_can( 'manage_woocommerce' ),
+			'hasCouponsEnabled'      => wc_coupons_enabled(),
+			'hasShippingEnabled'     => wc_get_shipping_method_count() > 0,
+			'activeShippingMethods'  => $active_methods,
+			'billingFields'          => $billing_fields,
+			'enabledPaymentGateways' => $enabled_payment_gateways,
 		);
 		?>
 		<script type="text/javascript">


### PR DESCRIPTION
Adds the payment gateways via JSON used in the cart block.

### Screenshots
<img width="477" alt="Screen Shot 2019-06-06 at 3 32 42 PM" src="https://user-images.githubusercontent.com/10561050/59036832-5842d380-8870-11e9-9ffb-c8fe64d4e105.png">

### How to test the changes in this Pull Request:

1. Edit any page with Gutenberg.
2. Note the contents of `wc_checkout_block_data` in the console.
3. Note that `enabledPaymentGateways` exists and required info for each payment gateway exists.

<!-- If you can, add the appropriate labels -->
