### PR TITLE
Add active shipping methods to checkout cart block

### DIFF
--- a/assets/js/blocks/checkout/cart/index.js
+++ b/assets/js/blocks/checkout/cart/index.js
@@ -17,6 +17,12 @@ registerBlockType( 'woocommerce/checkout-cart', {
 		html: false,
 	},
 	edit() {
+		const { hasShippingEnabled, activeShippingMethods } = wc_checkout_block_data;
+
+		const methods = Object.keys( activeShippingMethods ).map( method => {
+			return <li>{ activeShippingMethods[ method ].title }</li>;
+		} );
+
 		return (
 			<div className="wc-checkout__cart">
 				<h3>{ __( 'Your Order', 'woo-gutenberg-products-block' ) }</h3>
@@ -39,14 +45,16 @@ registerBlockType( 'woocommerce/checkout-cart', {
 							<td>$4.00</td>
 						</tr>
 
+						{ hasShippingEnabled && (
 						<tr>
 							<th>{ __( 'Shipping', 'woo-gutenberg-products-block' ) }</th>
 							<td>
 								<ul className="wc-checkout__cart-shipping-list">
-									<li>Shipping method: $1</li>
+									{ methods }
 								</ul>
 							</td>
 						</tr>
+						) }
 
 						<tr>
 							<th>{ __( 'Total', 'woo-gutenberg-products-block' ) }</th>

--- a/assets/js/blocks/checkout/cart/index.js
+++ b/assets/js/blocks/checkout/cart/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { RadioControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -19,8 +20,9 @@ registerBlockType( 'woocommerce/checkout-cart', {
 	edit() {
 		const { hasShippingEnabled, activeShippingMethods } = wc_checkout_block_data;
 
-		const methods = Object.keys( activeShippingMethods ).map( method => {
-			return <li>{ activeShippingMethods[ method ].title }</li>;
+		const methods = [];
+		Object.keys( activeShippingMethods ).forEach( method => {
+			methods.push( { label: activeShippingMethods[ method ].title, value: method } );
 		} );
 
 		return (
@@ -45,13 +47,15 @@ registerBlockType( 'woocommerce/checkout-cart', {
 							<td>$4.00</td>
 						</tr>
 
-						{ hasShippingEnabled && (
+						{ hasShippingEnabled && methods.length > 0 && (
 						<tr>
 							<th>{ __( 'Shipping', 'woo-gutenberg-products-block' ) }</th>
 							<td>
-								<ul className="wc-checkout__cart-shipping-list">
-									{ methods }
-								</ul>
+								<RadioControl
+									options={ methods }
+									selected={ methods[0].value }
+									onChange={ () => null }
+								/>
 							</td>
 						</tr>
 						) }


### PR DESCRIPTION
Replaces placeholder with real active shipping methods names from the `wc_checkout_block_data ` global if any are active.

Without shipping enabled:

![s1](https://user-images.githubusercontent.com/1177726/59038586-87a70f80-8873-11e9-9113-810b8502fa2f.png)

With shipping enabled:

<img width="945" alt="Screenshot 2019-06-06 at 16 41 29" src="https://user-images.githubusercontent.com/1177726/59042048-0b63fa80-887a-11e9-924a-8e50b7d1683f.png">
