### PR TITLE
Update checkout script name

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -150,7 +150,7 @@ class WGPB_Block_Library {
 		self::register_script( 'wc-product-top-rated', plugins_url( 'build/product-top-rated.js', WGPB_PLUGIN_FILE ), $block_dependencies );
 		self::register_script( 'wc-products-attribute', plugins_url( 'build/products-attribute.js', WGPB_PLUGIN_FILE ), $block_dependencies );
 		self::register_script( 'wc-featured-product', plugins_url( 'build/featured-product.js', WGPB_PLUGIN_FILE ), $block_dependencies );
-		self::register_script( 'wc-checkout', plugins_url( 'build/checkout.js', WGPB_PLUGIN_FILE ), $block_dependencies );
+		self::register_script( 'wc-checkout-block', plugins_url( 'build/checkout.js', WGPB_PLUGIN_FILE ), $block_dependencies );
 	}
 
 	/**
@@ -347,7 +347,7 @@ class WGPB_Block_Library {
 		register_block_type(
 			'woocommerce/checkout',
 			array(
-				'editor_script' => 'wc-checkout',
+				'editor_script' => 'wc-checkout-block',
 				'editor_style'  => 'wc-block-editor',
 				'style'         => 'wc-block-style',
 			)


### PR DESCRIPTION
Fix the script conflict.

To test

- Make sure the shipping fields on the checkout page are hidden by default