### PR TITLE
Add Privacy Policy block

### DIFF
--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -13,6 +13,7 @@ import './cart';
 import './checkbox';
 import './coupon';
 import './input';
+import './privacy-policy';
 import './radio';
 import './select';
 import './textarea';

--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -2,7 +2,7 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component } from '@wordpress/element';
+import { Component, RawHTML } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 
@@ -34,17 +34,21 @@ registerBlockType( 'woocommerce/checkout-privacy-policy', {
 		content: {
 			type: 'string',
 			source: 'html',
-			selector: 'p',
-			default: '',
+			default: privacyPolicy,
 		},
 	},
 	supports: {
+		className: false,
 		html: false,
 		multiple: false,
 	},
 	edit: Edit,
 	save( { attributes } ) {
 		const { content } = attributes;
-		return content || privacyPolicy;
+		return (
+			<RawHTML>
+				{ content }
+			</RawHTML>
+		);
 	},
 } );

--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -2,33 +2,49 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
+import { Component } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/editor';
+import { RichText } from '@wordpress/editor';
+
+const { privacyPolicy } = wc_checkout_block_data;
+
+class Edit extends Component {
+	componentDidMount() {
+		this.props.setAttributes( { content: privacyPolicy } );
+	}
+
+	render() {
+		const { attributes, setAttributes } = this.props;
+		const { content } = attributes;
+		return (
+			<RichText
+				tagName="p"
+				onChange={ ( nextValues ) => setAttributes( { content: nextValues } ) }
+				value={ content }
+			/>
+		);
+	}
+}
 
 registerBlockType( 'woocommerce/checkout-privacy-policy', {
 	title: __( 'Privacy Policy', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			selector: 'p',
+			default: '',
+		},
+	},
 	supports: {
 		html: false,
+		multiple: false,
 	},
-	edit() {
-		return (
-			<InnerBlocks
-				template={ [
-					[
-						'core/paragraph',
-						{
-							content: wc_checkout_block_data.privacyPolicy,
-							level: 3,
-						},
-					],
-				] }
-				templateLock="all"
-			/>
-		);
-	},
-	save() {
-		return <InnerBlocks.Content />;
+	edit: Edit,
+	save( { attributes } ) {
+		const { content } = attributes;
+		return content || privacyPolicy;
 	},
 } );

--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/editor';
+
+registerBlockType( 'woocommerce/checkout-privacy-policy', {
+	title: __( 'Privacy Policy', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<InnerBlocks
+				template={ [
+					[
+						'core/paragraph',
+						{
+							content: wc_checkout_block_data.privacyPolicy,
+							level: 3,
+						},
+					],
+				] }
+				templateLock="all"
+			/>
+		);
+	},
+	save() {
+		return <InnerBlocks.Content />;
+	},
+} );

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -462,6 +462,7 @@ class WGPB_Block_Library {
 			'activeShippingMethods'  => $active_methods,
 			'billingFields'          => $billing_fields,
 			'enabledPaymentGateways' => $enabled_payment_gateways,
+			'privacyPolicy'          => wc_get_privacy_policy_text( 'checkout' ),
 		);
 		?>
 		<script type="text/javascript">

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -662,10 +662,8 @@ class WGPB_Block_Library {
 				return;
 			}
 
-			$inner_blocks = $blocks[0]['innerBlocks'];
-			$content      = wp_list_pluck( $inner_blocks, 'innerHTML' );
-
-			update_option( 'woocommerce_checkout_privacy_policy_text', implode( '', $content ) );
+			$content = $blocks[0]['innerHTML'];
+			update_option( 'woocommerce_checkout_privacy_policy_text', $content );
 		}
 	}
 }

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -43,6 +43,7 @@ class WGPB_Block_Library {
 
 		if ( function_exists( 'register_block_type' ) ) {
 			add_action( 'init', array( 'WGPB_Block_Library', 'init' ) );
+			add_action( 'save_post', array( 'WGPB_Block_Library', 'save_data_to_settings' ), 10, 2 );
 		}
 	}
 
@@ -639,6 +640,33 @@ class WGPB_Block_Library {
 	public static function add_theme_body_class( $classes = array() ) {
 		$classes[] = 'theme-' . get_template();
 		return $classes;
+	}
+
+	/**
+	 * Update site options with post changes on publish/update.
+	 *
+	 * @param int     $post_id Post ID.
+	 * @param WP_Post $post    Post object.
+	 */
+	public static function save_data_to_settings( $post_id, $post ) {
+		if ( 'publish' !== $post->post_status ) {
+			return;
+		}
+
+		if ( has_block( 'woocommerce/checkout-privacy-policy', $post ) ) {
+			$blocks = wp_list_filter(
+				parse_blocks( $post->post_content ),
+				array( 'blockName' => 'woocommerce/checkout-privacy-policy' )
+			);
+			if ( empty( $blocks ) ) {
+				return;
+			}
+
+			$inner_blocks = $blocks[0]['innerBlocks'];
+			$content      = wp_list_pluck( $inner_blocks, 'innerHTML' );
+
+			update_option( 'woocommerce_checkout_privacy_policy_text', implode( '', $content ) );
+		}
 	}
 }
 

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -662,7 +662,7 @@ class WGPB_Block_Library {
 				return;
 			}
 
-			$content = $blocks[0]['innerHTML'];
+			$content = trim( $blocks[0]['innerHTML'] );
 			update_option( 'woocommerce_checkout_privacy_policy_text', $content );
 		}
 	}


### PR DESCRIPTION
Add the block & save the content to the `woocommerce_checkout_privacy_policy_text` when a post is published (or updated, if already published)

To test

- Add a Privacy Policy block to a post/page
- Change the text, save
- View your checkout page (the core one)
- Go into customizer and update the text
- Edit the post with Privacy Policy block <- this might be broken
- It should work
- Change it again, it should still work

