### PR TITLE
Add the coupon block to the parent checkout block

### DIFF
--- a/assets/js/blocks/checkout/coupon/index.js
+++ b/assets/js/blocks/checkout/coupon/index.js
@@ -1,0 +1,35 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import interpolateComponents from 'interpolate-components';
+import { registerBlockType } from '@wordpress/blocks';
+
+registerBlockType( 'woocommerce/checkout-coupon', {
+	title: __( 'Checkout Coupon', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<div className="woocommerce-info">
+				{
+					interpolateComponents( {
+						mixedString: __(
+							'Have a coupon? {{link}}Click here to enter your code{{/link}}',
+							'woocommerce-admin'
+						),
+						components: {
+							link: <span className="showcoupon" />,
+						},
+					} )
+				}
+			</div>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -11,6 +11,7 @@ import { InnerBlocks } from '@wordpress/editor';
 import './billing';
 import './cart';
 import './checkbox';
+import './coupon';
 import './input';
 import './radio';
 import './select';
@@ -27,6 +28,7 @@ registerBlockType( 'woocommerce/checkout', {
 		return (
 			<InnerBlocks
 				template={ [
+					[ 'woocommerce/checkout-coupon' ],
 					[ 'woocommerce/billing' ],
 					[ 'woocommerce/checkout-cart' ],
 				] }


### PR DESCRIPTION
Adds a coupon block which will later be styled.  Note a real link is not used since it won't be an active link and would not be accessible.

### Screenshots
<img width="642" alt="Screen Shot 2019-06-06 at 6 50 23 PM" src="https://user-images.githubusercontent.com/10561050/59050939-f55f3580-888b-11e9-888f-084d2e9cc4e9.png">

### How to test the changes in this Pull Request:

1.  Add the checkout block.
2.  Make sure the coupon block is shown at the top.