### PR TITLE
Add hidden notice to blocks

### DIFF
--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -3,7 +3,8 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { TextControl } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
+import { Notice, TextControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-input', {
 	title: __( 'Checkout Input', 'woo-gutenberg-products-block' ),
@@ -29,20 +30,31 @@ registerBlockType( 'woocommerce/checkout-input', {
 			type: 'boolean',
 			default: false,
 		},
+		isHidden: {
+			type: 'boolean',
+			default: false,
+		},
 	},
 	edit( { attributes } ) {
-		const { className, label, type, required } = attributes;
+		const { className, label, isHidden, type, required } = attributes;
 
 		return (
-			<TextControl
-				className={ className }
-				disabled
-				label={ label }
-				type={ type }
-				value=""
-				onChange={ () => {} }
-				required={ required }
-			/>
+			<Fragment>
+				{ isHidden && (
+					<Notice status="info" isDismissible={ false }>
+						{ __( 'This block is hidden. Visibility can be adjusted in the block settings sidebar.', 'woo-gutenberg-products-block' ) }
+					</Notice>
+				) }
+				<TextControl
+					className={ className }
+					disabled
+					label={ label }
+					type={ type }
+					value=""
+					onChange={ () => {} }
+					required={ required }
+				/>
+			</Fragment>
 		);
 	},
 	save() {

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -30,17 +30,17 @@ registerBlockType( 'woocommerce/checkout-input', {
 			type: 'boolean',
 			default: false,
 		},
-		isHidden: {
+		isVisible: {
 			type: 'boolean',
-			default: false,
+			default: true,
 		},
 	},
 	edit( { attributes } ) {
-		const { className, label, isHidden, type, required } = attributes;
+		const { className, label, isVisible, type, required } = attributes;
 
 		return (
 			<Fragment>
-				{ isHidden && (
+				{ Boolean( ! isVisible ) && (
 					<Notice status="info" isDismissible={ false }>
 						{ __( 'This block is hidden. Visibility can be adjusted in the block settings sidebar.', 'woo-gutenberg-products-block' ) }
 					</Notice>

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -36,7 +36,7 @@ registerBlockType( 'woocommerce/checkout-input', {
 		},
 	},
 	edit( { attributes } ) {
-		const { className, label, isVisible, type, required } = attributes;
+		const { className, isVisible, label, required, type } = attributes;
 
 		return (
 			<Fragment>


### PR DESCRIPTION
### Screenshots

![image](https://user-images.githubusercontent.com/3616980/59053732-63a6f680-8892-11e9-97cb-2db894660f27.png)

### How to test the changes in this Pull Request:

1. Modify the attribute so it's `false` by default:
```ES6
		isVisible: {
			type: 'boolean',
			default: false,
		},
```
2. Add a _Checkout_ blog to your page.
3. Verify the notice appears on top of text inputs.