### PR TITLE
Add place order button to blocks

### DIFF
--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -13,6 +13,7 @@ import './cart';
 import './checkbox';
 import './coupon';
 import './input';
+import './order-button';
 import './privacy-policy';
 import './radio';
 import './select';

--- a/assets/js/blocks/checkout/order-button/index.js
+++ b/assets/js/blocks/checkout/order-button/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/order-button', {
+	title: __( 'Checkout Place Order Button', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<Button className="wc-checkout__place-order-button">
+				{ __( 'Place order', 'woo-gutenberg-products-block' ) }
+			</Button>
+		);
+	},
+	save() {
+		return null;
+	},
+} );


### PR DESCRIPTION
Adds the place order button.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots
<img width="314" alt="Screen Shot 2019-06-07 at 11 15 48 AM" src="https://user-images.githubusercontent.com/10561050/59094137-cee5dc80-8915-11e9-84d8-6dd552f8c0ca.png">


### How to test the changes in this Pull Request:

1. Make sure you can add the place order button and that it does absolutely nothing.

<!-- If you can, add the appropriate labels -->
