### PR TITLE
Add page control component for selecting a privacy policy page

### DIFF
--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -2,11 +2,17 @@
  * External dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Component, RawHTML } from '@wordpress/element';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { InspectorControls, RichText } from '@wordpress/editor';
+import { PanelBody } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
-import { RichText } from '@wordpress/editor';
 
-const { privacyPolicy } = wc_checkout_block_data;
+/**
+ * Internal dependencies
+ */
+import PageControl from '../../../components/page-control';
+
+const { privacyPolicy, privacyPolicyId } = wc_checkout_block_data; // eslint-disable-line camelcase
 
 class Edit extends Component {
 	componentDidMount() {
@@ -15,13 +21,29 @@ class Edit extends Component {
 
 	render() {
 		const { attributes, setAttributes } = this.props;
-		const { content } = attributes;
+		const { content, privacyPolicyId: pageId } = attributes;
 		return (
-			<RichText
-				tagName="p"
-				onChange={ ( nextValues ) => setAttributes( { content: nextValues } ) }
-				value={ content }
-			/>
+			<Fragment>
+				<InspectorControls>
+					<PanelBody
+						title={ __( 'Select Page', 'woo-gutenberg-products-block' ) }
+						initialOpen
+					>
+						<PageControl
+							selected={ pageId || 0 }
+							onChange={ ( value = [] ) => {
+								const id = value[ 0 ] ? value[ 0 ].id : 0;
+								setAttributes( { privacyPolicyId: id } );
+							} }
+						/>
+					</PanelBody>
+				</InspectorControls>
+				<RichText
+					tagName="p"
+					onChange={ ( nextValues ) => setAttributes( { content: nextValues } ) }
+					value={ content }
+				/>
+			</Fragment>
 		);
 	}
 }
@@ -36,6 +58,10 @@ registerBlockType( 'woocommerce/checkout-privacy-policy', {
 			source: 'html',
 			default: privacyPolicy,
 		},
+		privacyPolicyId: {
+			type: 'number',
+			default: privacyPolicyId,
+		},
 	},
 	supports: {
 		className: false,
@@ -45,10 +71,6 @@ registerBlockType( 'woocommerce/checkout-privacy-policy', {
 	edit: Edit,
 	save( { attributes } ) {
 		const { content } = attributes;
-		return (
-			<RawHTML>
-				{ content }
-			</RawHTML>
-		);
+		return <RawHTML>{ content }</RawHTML>;
 	},
 } );

--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -16,7 +16,7 @@ const { privacyPolicy, privacyPolicyId } = wc_checkout_block_data; // eslint-dis
 
 class Edit extends Component {
 	componentDidMount() {
-		this.props.setAttributes( { content: privacyPolicy } );
+		this.props.setAttributes( { content: privacyPolicy, privacyPolicyId } );
 	}
 
 	render() {

--- a/assets/js/components/page-control/index.js
+++ b/assets/js/components/page-control/index.js
@@ -1,0 +1,93 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Component, Fragment } from '@wordpress/element';
+import { debounce, find } from 'lodash';
+import PropTypes from 'prop-types';
+import { SearchListControl } from '@woocommerce/components';
+
+/**
+ * Internal dependencies
+ */
+import { getPages } from '../utils';
+
+class PageControl extends Component {
+	constructor() {
+		super( ...arguments );
+		this.state = {
+			list: [],
+			loading: true,
+		};
+
+		this.debouncedOnSearch = debounce( this.onSearch.bind( this ), 400 );
+	}
+
+	componentDidMount() {
+		getPages( {} )
+			.then( ( list ) => {
+				this.setState( { list, loading: false } );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loading: false } );
+			} );
+	}
+
+	onSearch( search ) {
+		getPages( { search } )
+			.then( ( list ) => {
+				this.setState( { list, loading: false } );
+			} )
+			.catch( () => {
+				this.setState( { list: [], loading: false } );
+			} );
+	}
+
+	render() {
+		const { list, loading } = this.state;
+		const { onChange, selected } = this.props;
+		const messages = {
+			list: __( 'Pages', 'woo-gutenberg-products-block' ),
+			noItems: __(
+				"Your store doesn't have any pages.",
+				'woo-gutenberg-products-block'
+			),
+			search: __(
+				'Search for your privacy policy page.',
+				'woo-gutenberg-products-block'
+			),
+			updated: __(
+				'Page search results updated.',
+				'woo-gutenberg-products-block'
+			),
+		};
+
+		// Note: selected prop still needs to be array for SearchListControl.
+		return (
+			<Fragment>
+				<SearchListControl
+					className="woocommerce-pages"
+					list={ list }
+					isLoading={ loading }
+					isSingle
+					selected={ [ find( list, { id: selected } ) ] }
+					onChange={ onChange }
+					messages={ messages }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+PageControl.propTypes = {
+	/**
+	 * Callback to update the selected page.
+	 */
+	onChange: PropTypes.func.isRequired,
+	/**
+	 * The ID of the currently selected page.
+	 */
+	selected: PropTypes.number.isRequired,
+};
+
+export default PageControl;

--- a/assets/js/components/utils/index.js
+++ b/assets/js/components/utils/index.js
@@ -43,3 +43,21 @@ export const getProducts = ( { selected = [], search } ) => {
 		return uniqBy( flatten( data ), 'id' );
 	} );
 };
+
+/**
+ * Get a promise that resolves to a list of pages from the API.
+ *
+ * @param {object} - A query object with the list of selected pages and search term.
+ */
+export const getPages = ( { search = '' } ) => {
+	const path = addQueryArgs( '/wp/v2/pages', {
+		per_page: -1,
+		status: 'publish',
+		search,
+	} );
+
+	return apiFetch( { path } ).then( ( data ) => {
+		const pages = uniqBy( flatten( data ), 'id' );
+		return pages.map( ( p ) => ( { id: p.id, name: p.title.rendered } ) );
+	} );
+};

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -464,6 +464,7 @@ class WGPB_Block_Library {
 			'billingFields'          => $billing_fields,
 			'enabledPaymentGateways' => $enabled_payment_gateways,
 			'privacyPolicy'          => wc_get_privacy_policy_text( 'checkout' ),
+			'privacyPolicyId'        => wc_privacy_policy_page_id(),
 		);
 		?>
 		<script type="text/javascript">
@@ -663,7 +664,9 @@ class WGPB_Block_Library {
 			}
 
 			$content = trim( $blocks[0]['innerHTML'] );
+			$page_id = $blocks[0]['attrs']['privacyPolicyId'];
 			update_option( 'woocommerce_checkout_privacy_policy_text', $content );
+			update_option( 'wp_page_for_privacy_policy', $page_id );
 		}
 	}
 }


### PR DESCRIPTION
This adds a control in the sidebar for selecting a privacy policy page:

<img width="286" alt="Screen Shot 2019-06-07 at 11 28 53 AM" src="https://user-images.githubusercontent.com/541093/59094907-829b9c00-8917-11e9-854e-0a959525f0df.png">

To test

- Add a privacy policy block
- You should see the "Select page" panel in the sidebar
- Select a page, save/publish your post
- Your privacy policy page link should be updated on the checkout page