### PR TITLE
Add the terms block and group place order block

### DIFF
--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -13,6 +13,7 @@ import './cart';
 import './checkbox';
 import './coupon';
 import './input';
+import './order-button';
 import './privacy-policy';
 import './radio';
 import './select';

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -17,6 +17,7 @@ import './order-button';
 import './privacy-policy';
 import './radio';
 import './select';
+import './terms';
 import './textarea';
 
 registerBlockType( 'woocommerce/checkout', {

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -13,11 +13,9 @@ import './cart';
 import './checkbox';
 import './coupon';
 import './input';
-import './order-button';
-import './privacy-policy';
+import './place-order';
 import './radio';
 import './select';
-import './terms';
 import './textarea';
 
 registerBlockType( 'woocommerce/checkout', {
@@ -34,7 +32,7 @@ registerBlockType( 'woocommerce/checkout', {
 					[ 'woocommerce/checkout-coupon' ],
 					[ 'woocommerce/checkout-billing' ],
 					[ 'woocommerce/checkout-cart' ],
-					[ 'woocommerce/checkout-privacy-policy' ],
+					[ 'woocommerce/checkout-place-order' ],
 				] }
 				templateLock="all"
 			/>

--- a/assets/js/blocks/checkout/order-button/index.js
+++ b/assets/js/blocks/checkout/order-button/index.js
@@ -5,7 +5,7 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 
-registerBlockType( 'woocommerce/order-button', {
+registerBlockType( 'woocommerce/checkout-order-button', {
 	title: __( 'Checkout Place Order Button', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/js/blocks/checkout/order-button/index.js
+++ b/assets/js/blocks/checkout/order-button/index.js
@@ -1,0 +1,25 @@
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { Button } from '@wordpress/components';
+
+registerBlockType( 'woocommerce/order-button', {
+	title: __( 'Checkout Place Order Button', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<Button className="wc-checkout__place-order-button">
+				{ __( 'Place order', 'woo-gutenberg-products-block' ) }
+			</Button>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/place-order/index.js
+++ b/assets/js/blocks/checkout/place-order/index.js
@@ -29,6 +29,6 @@ registerBlockType( 'woocommerce/checkout-place-order', {
 		);
 	},
 	save() {
-		return null;
+		return <InnerBlocks.Content />;
 	},
 } );

--- a/assets/js/blocks/checkout/place-order/index.js
+++ b/assets/js/blocks/checkout/place-order/index.js
@@ -1,0 +1,34 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { registerBlockType } from '@wordpress/blocks';
+import { InnerBlocks } from '@wordpress/editor';
+
+import '../order-button';
+import '../privacy-policy';
+import '../terms';
+
+registerBlockType( 'woocommerce/checkout-place-order', {
+	title: __( 'Place Order', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	supports: {
+		html: false,
+	},
+	edit() {
+		return (
+			<InnerBlocks
+				template={ [
+					[ 'woocommerce/checkout-privacy-policy' ],
+					[ 'woocommerce/checkout-terms-and-conditions' ],
+					[ 'woocommerce/checkout-order-button' ],
+				] }
+				templateLock="all"
+			/>
+		);
+	},
+	save() {
+		return null;
+	},
+} );

--- a/assets/js/blocks/checkout/terms/index.js
+++ b/assets/js/blocks/checkout/terms/index.js
@@ -1,0 +1,63 @@
+/**
+ * External dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { CheckboxControl } from '@wordpress/components';
+import { Component, Fragment, RawHTML } from '@wordpress/element';
+import { registerBlockType } from '@wordpress/blocks';
+import { RichText } from '@wordpress/editor';
+
+const { termsAndConditions } = wc_checkout_block_data;
+
+class Edit extends Component {
+	componentDidMount() {
+		this.props.setAttributes( { content: termsAndConditions } );
+	}
+
+	render() {
+		const { attributes, setAttributes } = this.props;
+		const { content } = attributes;
+		return (
+			<Fragment>
+				<CheckboxControl
+					disabled
+					checked={ false }
+					onChange={ () => {} }
+					required={ true }
+				/>
+				<RichText
+					tagName="p"
+					onChange={ ( nextValues ) => setAttributes( { content: nextValues } ) }
+					value={ content }
+				/>
+			</Fragment>
+		);
+	}
+}
+
+registerBlockType( 'woocommerce/terms-and-conditions', {
+	title: __( 'Terms and Conditions', 'woo-gutenberg-products-block' ),
+	category: 'woocommerce-checkout',
+	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	attributes: {
+		content: {
+			type: 'string',
+			source: 'html',
+			default: termsAndConditions,
+		},
+	},
+	supports: {
+		className: false,
+		html: false,
+		multiple: false,
+	},
+	edit: Edit,
+	save( { attributes } ) {
+		const { content } = attributes;
+		return (
+			<RawHTML>
+				{ content }
+			</RawHTML>
+		);
+	},
+} );

--- a/assets/js/blocks/checkout/terms/index.js
+++ b/assets/js/blocks/checkout/terms/index.js
@@ -35,7 +35,7 @@ class Edit extends Component {
 	}
 }
 
-registerBlockType( 'woocommerce/terms-and-conditions', {
+registerBlockType( 'woocommerce/checkout-terms-and-conditions', {
 	title: __( 'Terms and Conditions', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -667,10 +667,10 @@ class WGPB_Block_Library {
 			update_option( 'woocommerce_checkout_privacy_policy_text', $content );
 		}
 
-		if ( has_block( 'woocommerce/terms-and-conditions', $post ) ) {
+		if ( has_block( 'woocommerce/checkout-terms-and-conditions', $post ) ) {
 			$blocks = wp_list_filter(
 				parse_blocks( $post->post_content ),
-				array( 'blockName' => 'woocommerce/terms-and-conditions' )
+				array( 'blockName' => 'woocommerce/checkout-terms-and-conditions' )
 			);
 			if ( empty( $blocks ) ) {
 				return;

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -464,6 +464,7 @@ class WGPB_Block_Library {
 			'billingFields'          => $billing_fields,
 			'enabledPaymentGateways' => $enabled_payment_gateways,
 			'privacyPolicy'          => wc_get_privacy_policy_text( 'checkout' ),
+			'termsAndConditions'     => wc_get_terms_and_conditions_checkbox_text(),
 		);
 		?>
 		<script type="text/javascript">
@@ -664,6 +665,19 @@ class WGPB_Block_Library {
 
 			$content = trim( $blocks[0]['innerHTML'] );
 			update_option( 'woocommerce_checkout_privacy_policy_text', $content );
+		}
+
+		if ( has_block( 'woocommerce/terms-and-conditions', $post ) ) {
+			$blocks = wp_list_filter(
+				parse_blocks( $post->post_content ),
+				array( 'blockName' => 'woocommerce/terms-and-conditions' )
+			);
+			if ( empty( $blocks ) ) {
+				return;
+			}
+
+			$content = trim( $blocks[0]['innerHTML'] );
+			update_option( 'woocommerce_checkout_terms_and_conditions_checkbox_text', $content );
 		}
 	}
 }


### PR DESCRIPTION
Adds the parent place order block that contains privacy, terms, and the place order button.

<!-- Don't forget to update the title with something descriptive. -->

### Screenshots

<img width="689" alt="Screen Shot 2019-06-07 at 12 07 55 PM" src="https://user-images.githubusercontent.com/10561050/59097793-c7770100-891e-11e9-9aef-db43afa34081.png">


### How to test the changes in this Pull Request:

1. Open a Gutenberg editor.
2. Add the Checkout block.
3. Make sure the 3 above blocks show and content for the privacy and terms saves appropriately.

<!-- If you can, add the appropriate labels -->
