### PR TITLE
Update the save function to handle nested blocks

### DIFF
--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -695,7 +695,7 @@ class WGPB_Block_Library {
 				return $block;
 			}
 			if ( ! empty( $block['innerBlocks'] ) ) {
-				$found_block = self::find_blocks( $block['innerBlocks'], $block_name );
+				$found_block = self::find_block( $block['innerBlocks'], $block_name );
 				if ( $found_block ) {
 					return $found_block;
 				}

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -665,8 +665,8 @@ class WGPB_Block_Library {
 			}
 			$checkout_block = reset( $blocks );
 
-			$privacy_block = self::find_blocks( $checkout_block['innerBlocks'], 'woocommerce/checkout-privacy-policy' );
-			$toc_block     = self::find_blocks( $checkout_block['innerBlocks'], 'woocommerce/checkout-terms-and-conditions' );
+			$privacy_block = self::find_block( $checkout_block['innerBlocks'], 'woocommerce/checkout-privacy-policy' );
+			$toc_block     = self::find_block( $checkout_block['innerBlocks'], 'woocommerce/checkout-terms-and-conditions' );
 
 			if ( $privacy_block ) {
 				$content = trim( $privacy_block['innerHTML'] );
@@ -689,7 +689,7 @@ class WGPB_Block_Library {
 	 * @param string $block_name Block type name to search for. When found, the block is returned.
 	 * @return array Associative array representing a block.
 	 */
-	public static function find_blocks( $blocks, $block_name ) {
+	public static function find_block( $blocks, $block_name ) {
 		foreach ( $blocks as $block ) {
 			if ( $block_name === $block['blockName'] ) {
 				return $block;

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -655,17 +655,26 @@ class WGPB_Block_Library {
 			return;
 		}
 
-		if ( has_block( 'woocommerce/checkout-privacy-policy', $post ) ) {
+		if ( has_block( 'woocommerce/checkout', $post ) ) {
 			$blocks = wp_list_filter(
 				parse_blocks( $post->post_content ),
-				array( 'blockName' => 'woocommerce/checkout-privacy-policy' )
+				array( 'blockName' => 'woocommerce/checkout' )
 			);
 			if ( empty( $blocks ) ) {
 				return;
 			}
+			$checkout_block = reset( $blocks );
 
-			$content = trim( $blocks[0]['innerHTML'] );
-			$page_id = $blocks[0]['attrs']['privacyPolicyId'];
+			// $inner_blocks is a pre-parsed list, so you can filter out to your specific block
+			// You might need to filter into innerBlocks again if you have another nested block (billing, etc).
+			$inner_blocks  = wp_list_filter(
+				$checkout_block['innerBlocks'],
+				array( 'blockName' => 'woocommerce/checkout-privacy-policy' )
+			);
+			$privacy_block = reset( $inner_blocks );
+
+			$content = trim( $privacy_block['innerHTML'] );
+			$page_id = $privacy_block['attrs']['privacyPolicyId'];
 			update_option( 'woocommerce_checkout_privacy_policy_text', $content );
 			update_option( 'wp_page_for_privacy_policy', $page_id );
 		}


### PR DESCRIPTION
Now that Privacy Policy is a child of checkout, we need to filter into `innerBlocks` to save the privacy policy content.