### PR TITLE
Add show asterisks setting

### DIFF
--- a/assets/js/blocks/checkout/billing/index.js
+++ b/assets/js/blocks/checkout/billing/index.js
@@ -5,10 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
 
-const getFieldBlock = ( field ) => {
+const getFieldBlock = ( field, showRequiredAsterisk ) => {
 	const className = Array.isArray( field.class ) ? field.class.join( ' ' ) : null;
 	const { label, required } = field;
-	const attributes = { className, label, required };
+	const attributes = { className, label, isRequired: required, showRequiredAsterisk };
 
 	switch ( field.type ) {
 		case 'textarea':
@@ -43,7 +43,7 @@ const getFieldBlock = ( field ) => {
 	}
 };
 
-const getFieldBlocks = () => {
+const getFieldBlocks = ( showRequiredAsterisk ) => {
 	if (
 		'object' !== typeof wc_checkout_block_data ||
 		'object' !== typeof wc_checkout_block_data.billingFields
@@ -52,18 +52,26 @@ const getFieldBlocks = () => {
 	}
 
 	return Object.values( wc_checkout_block_data.billingFields ).map( ( field ) =>
-		getFieldBlock( field )
+		getFieldBlock( field, showRequiredAsterisk )
 	);
 };
 
-registerBlockType( 'woocommerce/checkout-billing', {
+const blockConfiguration = {
 	title: __( 'Billing', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {
 		html: false,
 	},
-	edit() {
+	attributes: {
+		showRequiredAsterisk: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	edit( { attributes } ) {
+		const { showRequiredAsterisk } = attributes;
+
 		return (
 			<InnerBlocks
 				template={ [
@@ -74,7 +82,7 @@ registerBlockType( 'woocommerce/checkout-billing', {
 							level: 3,
 						},
 					],
-					...getFieldBlocks(),
+					...getFieldBlocks( showRequiredAsterisk ),
 				] }
 				templateLock="all"
 			/>
@@ -83,4 +91,8 @@ registerBlockType( 'woocommerce/checkout-billing', {
 	save() {
 		return <InnerBlocks.Content />;
 	},
-} );
+};
+
+registerBlockType( 'woocommerce/checkout-billing', blockConfiguration );
+
+registerBlockType( 'woocommerce/checkout-billing-with-asterisks', blockConfiguration );

--- a/assets/js/blocks/checkout/checkbox/index.js
+++ b/assets/js/blocks/checkout/checkbox/index.js
@@ -4,9 +4,10 @@
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { CheckboxControl } from '@wordpress/components';
+import { Fragment } from '@wordpress/element';
 
 registerBlockType( 'woocommerce/checkout-checkbox', {
-	title: __( 'Checkout checkbox', 'woo-gutenberg-products-block' ),
+	title: __( 'Checkout Checkbox', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {
@@ -25,23 +26,34 @@ registerBlockType( 'woocommerce/checkout-checkbox', {
 			type: 'string',
 			default: '',
 		},
-		required: {
+		isRequired: {
+			type: 'boolean',
+			default: false,
+		},
+		showRequiredAsterisk: {
 			type: 'boolean',
 			default: false,
 		},
 	},
 	edit( { attributes } ) {
-		const { className, heading, label, required } = attributes;
+		const { className, heading, label, isRequired, showRequiredAsterisk } = attributes;
+
+		const formattedLabel = showRequiredAsterisk && isRequired ? (
+			<Fragment>
+				{ label }
+				<abbr className="required" title="required">*</abbr>
+			</Fragment>
+		) : label;
 
 		return (
 			<CheckboxControl
 				classNames={ className }
 				disabled
 				heading={ heading }
-				label={ label }
+				label={ formattedLabel }
 				checked={ false }
 				onChange={ () => {} }
-				required={ required }
+				required={ isRequired }
 			/>
 		);
 	},

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -30,7 +30,7 @@ registerBlockType( 'woocommerce/checkout', {
 	attributes: {
 		showRequiredAsterisk: {
 			type: 'boolean',
-			default: false,
+			default: wc_checkout_block_data.highlightRequiredFields,
 		},
 	},
 	edit( { attributes, setAttributes } ) {

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -3,7 +3,9 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
-import { InnerBlocks } from '@wordpress/editor';
+import { InnerBlocks, InspectorControls } from '@wordpress/editor';
+import { Fragment } from '@wordpress/element';
+import { PanelBody, ToggleControl } from '@wordpress/components';
 
 /**
  * Internal dependencies
@@ -25,17 +27,38 @@ registerBlockType( 'woocommerce/checkout', {
 	supports: {
 		html: false,
 	},
-	edit() {
+	attributes: {
+		showRequiredAsterisk: {
+			type: 'boolean',
+			default: false,
+		},
+	},
+	edit( { attributes, setAttributes } ) {
+		const { showRequiredAsterisk } = attributes;
+		const billingName = showRequiredAsterisk ? 'woocommerce/checkout-billing-with-asterisks' : 'woocommerce/checkout-billing';
+
 		return (
-			<InnerBlocks
-				template={ [
-					[ 'woocommerce/checkout-coupon' ],
-					[ 'woocommerce/checkout-billing' ],
-					[ 'woocommerce/checkout-cart' ],
-					[ 'woocommerce/checkout-privacy-policy' ],
-				] }
-				templateLock="all"
-			/>
+			<Fragment>
+				<InnerBlocks
+					template={ [
+						[ 'woocommerce/checkout-coupon' ],
+						[ billingName, { showRequiredAsterisk } ],
+						[ 'woocommerce/checkout-cart' ],
+						[ 'woocommerce/checkout-privacy-policy' ],
+					] }
+					templateInsertUpdatesSelection={ false }
+					templateLock="all"
+				/>
+				<InspectorControls key="inspector">
+					<PanelBody title={ __( 'Content', 'woo-gutenberg-products-block' ) }>
+						<ToggleControl
+							label={ __( 'Highlight required fields with an asterisk', 'woo-gutenberg-products-block' ) }
+							checked={ showRequiredAsterisk }
+							onChange={ () => setAttributes( { showRequiredAsterisk: ! showRequiredAsterisk } ) }
+						/>
+					</PanelBody>
+				</InspectorControls>
+			</Fragment>
 		);
 	},
 	save() {

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -26,7 +26,11 @@ registerBlockType( 'woocommerce/checkout-input', {
 			type: 'string',
 			default: '',
 		},
-		required: {
+		isRequired: {
+			type: 'boolean',
+			default: false,
+		},
+		showRequiredAsterisk: {
 			type: 'boolean',
 			default: false,
 		},
@@ -36,7 +40,14 @@ registerBlockType( 'woocommerce/checkout-input', {
 		},
 	},
 	edit( { attributes } ) {
-		const { className, isVisible, label, required, type } = attributes;
+		const { className, label, type, isVisible, isRequired, showRequiredAsterisk } = attributes;
+
+		const formattedLabel = showRequiredAsterisk && isRequired ? (
+			<Fragment>
+				{ label + ' ' }
+				<abbr className="required" title="required">*</abbr>
+			</Fragment>
+		) : label;
 
 		return (
 			<Fragment>
@@ -51,11 +62,11 @@ registerBlockType( 'woocommerce/checkout-input', {
 				<TextControl
 					className={ className }
 					disabled
-					label={ label }
+					label={ formattedLabel }
 					type={ type }
 					value=""
 					onChange={ () => {} }
-					required={ required }
+					required={ isRequired }
 				/>
 			</Fragment>
 		);

--- a/assets/js/blocks/checkout/radio/index.js
+++ b/assets/js/blocks/checkout/radio/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { Fragment } from '@wordpress/element';
 import { RadioControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-radio', {
@@ -25,23 +26,34 @@ registerBlockType( 'woocommerce/checkout-radio', {
 			type: 'string',
 			default: '',
 		},
-		required: {
+		isRequired: {
+			type: 'boolean',
+			default: false,
+		},
+		showRequiredAsterisk: {
 			type: 'boolean',
 			default: false,
 		},
 	},
 	edit( { attributes } ) {
-		const { className, label, options, required } = attributes;
+		const { className, label, options, showRequiredAsterisk, isRequired } = attributes;
+
+		const formattedLabel = showRequiredAsterisk && isRequired ? (
+			<Fragment>
+				{ label }
+				<abbr className="required" title="required">*</abbr>
+			</Fragment>
+		) : label;
 
 		return (
 			<RadioControl
 				className={ className }
 				disabled
-				label={ label }
+				label={ formattedLabel }
 				selected={ null }
 				options={ options }
 				onChange={ () => {} }
-				required={ required }
+				required={ isRequired }
 			/>
 		);
 	},

--- a/assets/js/blocks/checkout/select/index.js
+++ b/assets/js/blocks/checkout/select/index.js
@@ -3,10 +3,11 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { Fragment } from '@wordpress/element';
 import { SelectControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-select', {
-	title: __( 'Checkout select', 'woo-gutenberg-products-block' ),
+	title: __( 'Checkout Select', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {
@@ -21,23 +22,34 @@ registerBlockType( 'woocommerce/checkout-select', {
 			type: 'string',
 			default: '',
 		},
-		required: {
+		isRequired: {
+			type: 'boolean',
+			default: false,
+		},
+		showRequiredAsterisk: {
 			type: 'boolean',
 			default: false,
 		},
 	},
 	edit( { attributes } ) {
-		const { className, label, required } = attributes;
+		const { className, label, showRequiredAsterisk, isRequired } = attributes;
+
+		const formattedLabel = showRequiredAsterisk && isRequired ? (
+			<Fragment>
+				{ label }
+				<abbr className="required" title="required">*</abbr>
+			</Fragment>
+		) : label;
 
 		return (
 			<SelectControl
 				className={ className }
 				disabled
-				label={ label }
+				label={ formattedLabel }
 				value=""
 				options={ [ { label: '', value: '' } ] }
 				onChange={ () => {} }
-				required={ required }
+				required={ isRequired }
 			/>
 		);
 	},

--- a/assets/js/blocks/checkout/textarea/index.js
+++ b/assets/js/blocks/checkout/textarea/index.js
@@ -3,6 +3,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
+import { Fragment } from '@wordpress/element';
 import { TextareaControl } from '@wordpress/components';
 
 registerBlockType( 'woocommerce/checkout-textarea', {
@@ -21,22 +22,33 @@ registerBlockType( 'woocommerce/checkout-textarea', {
 			type: 'string',
 			default: '',
 		},
-		required: {
+		isRequired: {
+			type: 'boolean',
+			default: false,
+		},
+		showRequiredAsterisk: {
 			type: 'boolean',
 			default: false,
 		},
 	},
 	edit( { attributes } ) {
-		const { className, label, required } = attributes;
+		const { className, label, showRequiredAsterisk, isRequired } = attributes;
+
+		const formattedLabel = showRequiredAsterisk && isRequired ? (
+			<Fragment>
+				{ label }
+				<abbr className="required" title="required">*</abbr>
+			</Fragment>
+		) : label;
 
 		return (
 			<TextareaControl
 				className={ className }
 				disabled
-				label={ label }
+				label={ formattedLabel }
 				value=""
 				onChange={ () => {} }
-				required={ required }
+				required={ isRequired }
 			/>
 		);
 	},

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -457,15 +457,16 @@ class WGPB_Block_Library {
 		$billing_fields = WC()->checkout->get_checkout_fields( 'billing' );
 
 		$checkout_settings = array(
-			'isUserShopManager'      => current_user_can( 'manage_woocommerce' ),
-			'hasCouponsEnabled'      => wc_coupons_enabled(),
-			'hasShippingEnabled'     => wc_get_shipping_method_count() > 0,
-			'activeShippingMethods'  => $active_methods,
-			'billingFields'          => $billing_fields,
-			'enabledPaymentGateways' => $enabled_payment_gateways,
-			'privacyPolicy'          => wc_get_privacy_policy_text( 'checkout' ),
-			'privacyPolicyId'        => wc_privacy_policy_page_id(),
-			'termsAndConditions'     => wc_get_terms_and_conditions_checkbox_text(),
+			'isUserShopManager'       => current_user_can( 'manage_woocommerce' ),
+			'hasCouponsEnabled'       => wc_coupons_enabled(),
+			'hasShippingEnabled'      => wc_get_shipping_method_count() > 0,
+			'activeShippingMethods'   => $active_methods,
+			'billingFields'           => $billing_fields,
+			'enabledPaymentGateways'  => $enabled_payment_gateways,
+			'privacyPolicy'           => wc_get_privacy_policy_text( 'checkout' ),
+			'privacyPolicyId'         => wc_privacy_policy_page_id(),
+			'termsAndConditions'      => wc_get_terms_and_conditions_checkbox_text(),
+			'highlightRequiredFields' => wc_string_to_bool( get_option( 'woocommerce_checkout_highlight_required_fields', 'yes' ) ),
 		);
 		?>
 		<script type="text/javascript">


### PR DESCRIPTION
This PR registers two blocks which are identical but have a different name `woocommerce/checkout-billing` and `woocommerce/checkout-billing-with-asterisks`, this way we can switch between them to make sure child blocks are updated with or without the asterisks when the attribute changes.

Not a very clean solution, but couldn't get with any better idea that worked.

### Screenshots

![Peek 2019-06-07 12-59](https://user-images.githubusercontent.com/3616980/59099669-11161a80-8924-11e9-8a3f-ccc429977535.gif)

### How to test the changes in this Pull Request:

1. Add a _Checkout_ block to any post or page.
2. Toggle the asterisk preferences on the right.
3. Verify changes are applied to the fields.

### Issues

* I don't know why when toggling the preference the header block is focused. Couldn't get rid of this behaviour. I thought `templateInsertUpdatesSelection` would prevent that, but it doesn't. :confused: 
