### PR TITLE
Add block restrictions to all children blocks

### DIFF
--- a/assets/js/blocks/checkout/billing/index.js
+++ b/assets/js/blocks/checkout/billing/index.js
@@ -60,8 +60,11 @@ registerBlockType( 'woocommerce/checkout-billing', {
 	title: __( 'Billing', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	edit() {
 		return (

--- a/assets/js/blocks/checkout/cart/index.js
+++ b/assets/js/blocks/checkout/cart/index.js
@@ -14,8 +14,11 @@ registerBlockType( 'woocommerce/checkout-cart', {
 	title: __( 'Cart', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	edit() {
 		const {

--- a/assets/js/blocks/checkout/checkbox/index.js
+++ b/assets/js/blocks/checkout/checkbox/index.js
@@ -9,8 +9,11 @@ registerBlockType( 'woocommerce/checkout-checkbox', {
 	title: __( 'Checkout checkbox', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout-billing' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	attributes: {
 		heading: {

--- a/assets/js/blocks/checkout/checkbox/index.js
+++ b/assets/js/blocks/checkout/checkbox/index.js
@@ -13,7 +13,6 @@ registerBlockType( 'woocommerce/checkout-checkbox', {
 	supports: {
 		html: false,
 		inserter: false,
-		multiple: false,
 	},
 	attributes: {
 		heading: {

--- a/assets/js/blocks/checkout/coupon/index.js
+++ b/assets/js/blocks/checkout/coupon/index.js
@@ -9,8 +9,11 @@ registerBlockType( 'woocommerce/checkout-coupon', {
 	title: __( 'Checkout Coupon', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	edit() {
 		return (

--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -24,6 +24,7 @@ registerBlockType( 'woocommerce/checkout', {
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
 	supports: {
 		html: false,
+		multiple: false,
 	},
 	edit() {
 		return (

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -14,7 +14,6 @@ registerBlockType( 'woocommerce/checkout-input', {
 	supports: {
 		html: false,
 		inserter: false,
-		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/input/index.js
+++ b/assets/js/blocks/checkout/input/index.js
@@ -10,8 +10,11 @@ registerBlockType( 'woocommerce/checkout-input', {
 	title: __( 'Checkout Input', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout-billing' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/order-button/index.js
+++ b/assets/js/blocks/checkout/order-button/index.js
@@ -9,8 +9,11 @@ registerBlockType( 'woocommerce/checkout-order-button', {
 	title: __( 'Checkout Place Order Button', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout-place-order' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	edit() {
 		return (

--- a/assets/js/blocks/checkout/place-order/index.js
+++ b/assets/js/blocks/checkout/place-order/index.js
@@ -13,8 +13,11 @@ registerBlockType( 'woocommerce/checkout-place-order', {
 	title: __( 'Place Order', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	edit() {
 		return (

--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -63,9 +63,11 @@ registerBlockType( 'woocommerce/checkout-privacy-policy', {
 			default: privacyPolicyId,
 		},
 	},
+	parent: [ 'woocommerce/checkout-place-order' ],
 	supports: {
 		className: false,
 		html: false,
+		inserter: false,
 		multiple: false,
 	},
 	edit: Edit,

--- a/assets/js/blocks/checkout/radio/index.js
+++ b/assets/js/blocks/checkout/radio/index.js
@@ -9,8 +9,11 @@ registerBlockType( 'woocommerce/checkout-radio', {
 	title: __( 'Checkout Radio', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout-billing' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/radio/index.js
+++ b/assets/js/blocks/checkout/radio/index.js
@@ -13,7 +13,6 @@ registerBlockType( 'woocommerce/checkout-radio', {
 	supports: {
 		html: false,
 		inserter: false,
-		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/select/index.js
+++ b/assets/js/blocks/checkout/select/index.js
@@ -13,7 +13,6 @@ registerBlockType( 'woocommerce/checkout-select', {
 	supports: {
 		html: false,
 		inserter: false,
-		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/select/index.js
+++ b/assets/js/blocks/checkout/select/index.js
@@ -9,8 +9,11 @@ registerBlockType( 'woocommerce/checkout-select', {
 	title: __( 'Checkout select', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout-billing' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/terms/index.js
+++ b/assets/js/blocks/checkout/terms/index.js
@@ -46,9 +46,11 @@ registerBlockType( 'woocommerce/checkout-terms-and-conditions', {
 			default: termsAndConditions,
 		},
 	},
+	parent: [ 'woocommerce/checkout-place-order' ],
 	supports: {
 		className: false,
 		html: false,
+		inserter: false,
 		multiple: false,
 	},
 	edit: Edit,

--- a/assets/js/blocks/checkout/textarea/index.js
+++ b/assets/js/blocks/checkout/textarea/index.js
@@ -13,7 +13,6 @@ registerBlockType( 'woocommerce/checkout-textarea', {
 	supports: {
 		html: false,
 		inserter: false,
-		multiple: false,
 	},
 	attributes: {
 		label: {

--- a/assets/js/blocks/checkout/textarea/index.js
+++ b/assets/js/blocks/checkout/textarea/index.js
@@ -9,8 +9,11 @@ registerBlockType( 'woocommerce/checkout-textarea', {
 	title: __( 'Checkout Textarea', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
 	keywords: [ __( 'WooCommerce', 'woo-gutenberg-products-block' ) ],
+	parent: [ 'woocommerce/checkout-billing' ],
 	supports: {
 		html: false,
+		inserter: false,
+		multiple: false,
 	},
 	attributes: {
 		label: {


### PR DESCRIPTION
This adds all the correct supports to all checkout blocks– this disallows HTML editing, removes each block from the inserter, and restricts inserting multiple blocks (so only one "Billing" block can exist) - except on the input blocks, since these are repeatable.

**To test**

- Check that only Checkout exists under the WooCommerce Checkout category
- Check that all the fields exist in the checkout