### PR TITLE
Add all checkout block styles

### DIFF
--- a/assets/js/blocks/checkout/billing/editor.scss
+++ b/assets/js/blocks/checkout/billing/editor.scss
@@ -1,0 +1,25 @@
+div[data-type="woocommerce/checkout-input"].editor-block-list__block,
+div[data-type="woocommerce/checkout-radio"].editor-block-list__block,
+div[data-type="woocommerce/checkout-textarea"].editor-block-list__block,
+div[data-type="woocommerce/checkout-select"].editor-block-list__block {
+	.editor-block-list__block-edit {
+		margin-top: 15px;
+		margin-bottom: 15px;
+
+		&::before {
+			top: -9px;
+			bottom: -9px;
+		}
+	}
+
+	.components-base-control__label {
+		font-size: 22px;
+	}
+
+	.components-text-control__input,
+	.components-select-control__input {
+		height: 50px;
+		box-sizing: border-box;
+		border: 1px solid #ccc;
+	}
+}

--- a/assets/js/blocks/checkout/billing/index.js
+++ b/assets/js/blocks/checkout/billing/index.js
@@ -5,6 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 const getFieldBlock = ( field, showRequiredAsterisk ) => {
 	const { shopCountry } = wc_checkout_block_data;
 	const className = Array.isArray( field.class ) ? field.class.join( ' ' ) : null;

--- a/assets/js/blocks/checkout/cart/editor.scss
+++ b/assets/js/blocks/checkout/cart/editor.scss
@@ -2,17 +2,31 @@
 
 .wc-checkout__cart-table {
 	border-collapse: collapse;
+	border-top: 2px solid #767676;
+	border-bottom: 2px solid #767676;
 	width: 100%;
 	// twentynineteen compat?
 	font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Fira Sans", "Droid Sans", "Helvetica Neue", sans-serif;
 
 	td,
 	th {
-		padding: 0.5em 0.3em;
-		border: 1px solid currentColor;
+		padding: $gap $gap-large;
+		text-align: left;
+	}
+	
+	th {
+		background:  #f5f5f5;
 	}
 
+	.wc-checkout__cart-table-total {
+		font-weight: bold;
+	}
+	
 	.wc-checkout__cart-shipping-list {
 		padding-left: 1em;
+	}
+
+	.components-radio-control {
+		font-size: 22px;
 	}
 }

--- a/assets/js/blocks/checkout/cart/index.js
+++ b/assets/js/blocks/checkout/cart/index.js
@@ -33,7 +33,7 @@ registerBlockType( 'woocommerce/checkout-cart', {
 
 		return (
 			<div className="wc-checkout__cart">
-				<h3>{ __( 'Your Order', 'woo-gutenberg-products-block' ) }</h3>
+				<h3>{ __( 'Your order', 'woo-gutenberg-products-block' ) }</h3>
 				<table className="wc-checkout__cart-table">
 					<thead>
 						<tr>
@@ -68,7 +68,7 @@ registerBlockType( 'woocommerce/checkout-cart', {
 							</tr>
 						) }
 
-						<tr>
+						<tr className="wc-checkout__cart-table-total">
 							<th>{ __( 'Total', 'woo-gutenberg-products-block' ) }</th>
 							<td>$5.00</td>
 						</tr>

--- a/assets/js/blocks/checkout/coupon/editor.scss
+++ b/assets/js/blocks/checkout/coupon/editor.scss
@@ -1,0 +1,12 @@
+.wc-checkout__coupon {
+	background: #3d9cd2;
+	color: #fff;
+	padding: $gap $gap-large;
+	border-left: 5px solid #0086b6;
+	border-radius: 2px;
+}
+
+.wc-checkout__coupon-show-coupon {
+	text-decoration: underline;
+	cursor: pointer;
+}

--- a/assets/js/blocks/checkout/coupon/index.js
+++ b/assets/js/blocks/checkout/coupon/index.js
@@ -5,6 +5,11 @@ import { __ } from '@wordpress/i18n';
 import interpolateComponents from 'interpolate-components';
 import { registerBlockType } from '@wordpress/blocks';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 registerBlockType( 'woocommerce/checkout-coupon', {
 	title: __( 'Checkout Coupon', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',
@@ -14,14 +19,14 @@ registerBlockType( 'woocommerce/checkout-coupon', {
 	},
 	edit() {
 		return (
-			<div className="woocommerce-info">
+			<div className="wc-checkout__coupon">
 				{ interpolateComponents( {
 					mixedString: __(
 						'Have a coupon? {{link}}Click here to enter your code{{/link}}',
 						'woocommerce-admin'
 					),
 					components: {
-						link: <span className="showcoupon" />,
+						link: <span className="wc-checkout__coupon-show-coupon" />,
 					},
 				} ) }
 			</div>

--- a/assets/js/blocks/checkout/order-button/editor.scss
+++ b/assets/js/blocks/checkout/order-button/editor.scss
@@ -1,0 +1,8 @@
+.wc-checkout__place-order-button {
+	background-color: #0073aa;
+	color: #fff;
+	padding: $gap $gap-larger;
+	font-size: 22px;
+	float: right;
+	border-radius: 5px;
+}

--- a/assets/js/blocks/checkout/order-button/index.js
+++ b/assets/js/blocks/checkout/order-button/index.js
@@ -5,6 +5,11 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { Button } from '@wordpress/components';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 registerBlockType( 'woocommerce/checkout-order-button', {
 	title: __( 'Checkout Place Order Button', 'woo-gutenberg-products-block' ),
 	category: 'woocommerce-checkout',

--- a/assets/js/blocks/checkout/place-order/editor.scss
+++ b/assets/js/blocks/checkout/place-order/editor.scss
@@ -1,0 +1,6 @@
+.wc-checkout__place-order {
+	background: #f7f7f7;
+	padding: $gap-large;
+	display: inline-block;
+    width: 100%;
+}

--- a/assets/js/blocks/checkout/place-order/index.js
+++ b/assets/js/blocks/checkout/place-order/index.js
@@ -5,6 +5,10 @@ import { __ } from '@wordpress/i18n';
 import { registerBlockType } from '@wordpress/blocks';
 import { InnerBlocks } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
 import '../order-button';
 import '../payment-options';
 import '../privacy-policy';

--- a/assets/js/blocks/checkout/terms/editor.scss
+++ b/assets/js/blocks/checkout/terms/editor.scss
@@ -1,0 +1,6 @@
+div[data-type="woocommerce/checkout-terms-and-conditions"] {
+	.components-base-control {
+		margin-top: 5px;
+		float: left;
+	}
+}

--- a/assets/js/blocks/checkout/terms/index.js
+++ b/assets/js/blocks/checkout/terms/index.js
@@ -7,6 +7,11 @@ import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { registerBlockType } from '@wordpress/blocks';
 import { RichText } from '@wordpress/editor';
 
+/**
+ * Internal dependencies
+ */
+import './editor.scss';
+
 const { termsAndConditions } = wc_checkout_block_data;
 
 class Edit extends Component {


### PR DESCRIPTION
All the styles.

### Screenshots

<img width="859" alt="Screen Shot 2019-06-07 at 3 28 15 PM" src="https://user-images.githubusercontent.com/10561050/59107417-e4b8c900-8938-11e9-9bba-7420df526c46.png">


### How to test the changes in this Pull Request:

1. Add the checkout block.
2. Styles look good?
