### PR TITLE
Updates to privacy policy when no page is selected

### DIFF
--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -4,7 +4,7 @@
 import { __ } from '@wordpress/i18n';
 import { Component, Fragment, RawHTML } from '@wordpress/element';
 import { InspectorControls, RichText } from '@wordpress/editor';
-import { PanelBody } from '@wordpress/components';
+import { Notice, PanelBody } from '@wordpress/components';
 import { registerBlockType } from '@wordpress/blocks';
 
 /**
@@ -38,6 +38,14 @@ class Edit extends Component {
 						/>
 					</PanelBody>
 				</InspectorControls>
+				{ ! pageId && (
+					<Notice status="info" isDismissible={ false }>
+						{ __(
+							'This block is hidden. Select a privacy policy page in the sidebar to show it.',
+							'woo-gutenberg-products-block'
+						) }
+					</Notice>
+				) }
 				<RichText
 					tagName="p"
 					onChange={ ( nextValues ) => setAttributes( { content: nextValues } ) }

--- a/assets/php/class-wgpb-block-library.php
+++ b/assets/php/class-wgpb-block-library.php
@@ -716,9 +716,14 @@ class WGPB_Block_Library {
 
 			if ( $privacy_block ) {
 				$content = trim( $privacy_block['innerHTML'] );
-				$page_id = $privacy_block['attrs']['privacyPolicyId'];
 				update_option( 'woocommerce_checkout_privacy_policy_text', $content );
-				update_option( 'wp_page_for_privacy_policy', $page_id );
+
+				if ( isset( $privacy_block['attrs']['privacyPolicyId'] ) ) {
+					$page_id = $privacy_block['attrs']['privacyPolicyId'];
+					update_option( 'wp_page_for_privacy_policy', $page_id );
+				} else {
+					update_option( 'wp_page_for_privacy_policy', false );
+				}
 			}
 
 			if ( $toc_block ) {


### PR DESCRIPTION
Fix privacyPolicyId error when no page is selected – this should delete the saved page, turning off the "privacy policy" notice. It also adds the "hidden" notice when privacy policy is disabled (turned off).

**To test**

- On the privacy block, unselect a Privacy Policy page
- Save the post
- There should be no PHP Notice
- The block should have a warning notice now
- View the checkout, no privacy policy text should appear.