### PR TITLE
Save the shortcode to the page content

### DIFF
--- a/assets/js/blocks/checkout/index.js
+++ b/assets/js/blocks/checkout/index.js
@@ -35,7 +35,9 @@ registerBlockType( 'woocommerce/checkout', {
 	},
 	edit( { attributes, setAttributes } ) {
 		const { showRequiredAsterisk } = attributes;
-		const billingName = showRequiredAsterisk ? 'woocommerce/checkout-billing-with-asterisks' : 'woocommerce/checkout-billing';
+		const billingName = showRequiredAsterisk ?
+			'woocommerce/checkout-billing-with-asterisks' :
+			'woocommerce/checkout-billing';
 
 		return (
 			<Fragment>
@@ -52,9 +54,14 @@ registerBlockType( 'woocommerce/checkout', {
 				<InspectorControls key="inspector">
 					<PanelBody title={ __( 'Content', 'woo-gutenberg-products-block' ) }>
 						<ToggleControl
-							label={ __( 'Highlight required fields with an asterisk', 'woo-gutenberg-products-block' ) }
+							label={ __(
+								'Highlight required fields with an asterisk',
+								'woo-gutenberg-products-block'
+							) }
 							checked={ showRequiredAsterisk }
-							onChange={ () => setAttributes( { showRequiredAsterisk: ! showRequiredAsterisk } ) }
+							onChange={ () =>
+								setAttributes( { showRequiredAsterisk: ! showRequiredAsterisk } )
+							}
 						/>
 					</PanelBody>
 				</InspectorControls>
@@ -62,6 +69,11 @@ registerBlockType( 'woocommerce/checkout', {
 		);
 	},
 	save() {
-		return <InnerBlocks.Content />;
+		return (
+			<Fragment>
+				<InnerBlocks.Content />
+				[woocommerce_checkout]
+			</Fragment>
+		);
 	},
 } );


### PR DESCRIPTION
This updates the main block's save function to add the checkout shortcode. Currently since we save the privacy policy + terms strings as content, they're displayed on the front-end twice, but at least the checkout is actually added to the page.

<img width="771" alt="Screen Shot 2019-06-07 at 4 11 02 PM" src="https://user-images.githubusercontent.com/541093/59110216-eb4a3f00-893e-11e9-8896-390e1bd2af18.png">

