### PR TITLE
Fix the default privacy policy page

### DIFF
--- a/assets/js/blocks/checkout/privacy-policy/index.js
+++ b/assets/js/blocks/checkout/privacy-policy/index.js
@@ -60,7 +60,7 @@ registerBlockType( 'woocommerce/checkout-privacy-policy', {
 		},
 		privacyPolicyId: {
 			type: 'number',
-			default: privacyPolicyId,
+			default: 0,
 		},
 	},
 	parent: [ 'woocommerce/checkout-place-order' ],


### PR DESCRIPTION
If the selected privacy policy page is not changed, gutenberg sees it as "default" and removes it from the attributes- this removes the page, turning off the privacy policy notice. This fixes that by setting the default to 0.